### PR TITLE
Escape dots in regular expressions

### DIFF
--- a/src/rails_rspec_file_toggle.ts
+++ b/src/rails_rspec_file_toggle.ts
@@ -15,7 +15,7 @@ export default class RailsRspecFileToggle {
   }
 
   private openSpecFromApp(filePath: string, rootPath: string) {
-    const regex = new RegExp(`^${rootPath}/app/(.*)\.rb$`);
+    const regex = new RegExp(`^${rootPath}/app/(.*)\\.rb$`);
     const match = filePath.match(regex);
     if (match) {
       const file = ConvertDefinition.convertAppToSpec(match[1]);
@@ -26,7 +26,7 @@ export default class RailsRspecFileToggle {
   }
 
   private openAppFromSpec(filePath: string, rootPath: string) {
-    const regex = new RegExp(`^${rootPath}/${Configuration.shared.getRspecDirectory()}/(.*)_spec\.rb$`);
+    const regex = new RegExp(`^${rootPath}/${Configuration.shared.getRspecDirectory()}/(.*)_spec\\.rb$`);
     const match = filePath.match(regex);
     if (match) {
       const file = ConvertDefinition.convertSpecToApp(match[1]);


### PR DESCRIPTION
When trying to apply changes for #2 I understood that the issue I was having comes from the fact that the toggler should *not* be opening `.html.erb` files in the first place.

This fixes it by properly escaping the `.` in `.rb` so it doesn’t match `erb`.

Closes #2